### PR TITLE
add flake.nix, $ nix develop works, $ nix build doesnt work

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,99 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1760423683,
+        "narHash": "sha256-Tb+NYuJhWZieDZUxN6PgglB16yuqBYQeMJyYBGCXlt8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a493e93b4a259cd9fea8073f89a7ed9b1c5a1da2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1760284886,
+        "narHash": "sha256-TK9Kr0BYBQ/1P5kAsnNQhmWWKgmZXwUQr4ZMjCzWf2c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cf3f5c4def3c7b5f1fc012b3d839575dbe552d43",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1760495781,
+        "narHash": "sha256-3OGPAQNJswy6L4VJyX3U9/z7fwgPFvK6zQtB2NHBV0Y=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "11e0852a2aa3a65955db5824262d76933750e299",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,221 @@
+{
+  description = "Cuervo terminal based browser embedded TUI app, using Servo browser engine embedded";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, nixpkgs-unstable, flake-utils, rust-overlay, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = overlays;
+        };
+        unstable = import nixpkgs-unstable {
+          inherit system;
+          overlays = overlays;
+        };
+        rustPlatform = pkgs.makeRustPlatform {
+          cargo = pkgs.cargo;
+          rustc = pkgs.rustc;
+        };
+        llvmPackage = pkgs.llvmPackages_21;
+      in rec {
+        checks = {
+          clippy = pkgs.writeShellApplication {
+            name = "clippy-check";
+            runtimeInputs = [ pkgs.rustc pkgs.cargo ];
+            text = ''
+              cargo clippy --all-targets --all-features -- -D warnings
+            '';
+          };
+
+          fmt = pkgs.writeShellApplication {
+            name = "fmt-check";
+            runtimeInputs = [ pkgs.rustfmt ];
+            text = ''
+              cargo fmt -- --check
+            '';
+          };
+
+          test = pkgs.writeShellApplication {
+            name = "test-check";
+            runtimeInputs = [ pkgs.rustc pkgs.cargo ];
+            text = ''
+              cargo test
+            '';
+          };
+
+          # NOTE: cuervo doesnt have a one-off output on process call thus this is commented out for now:
+          # output = pkgs.nixosTest {
+          #   name = "rust-output-test";
+          #   nodes.machine = { config, pkgs, ... }: {
+          #     environment.systemPackages = [ self.packages.${system}.default ];
+          #     system.stateVersion = pkgs.lib.versions.majorMinor pkgs.lib.version;
+          #   };
+          #
+          #   testScript = ''
+          #     machine.wait_for_unit("default.target")
+          #     # machine.succeed("cuervo --help | grep -o \"Cuervo\")
+          #
+          #     # machine.succeed("systemd-run --unit=cuervo cuervo --help")
+          #   '';
+          # };
+        };
+
+        devShells.default = pkgs.mkShell {
+          nativeBuildInputs = [
+            pkgs.rustfmt
+            pkgs.clippy
+
+            self.packages.${system}.default.nativeBuildInputs
+          ];
+
+          buildInputs = [
+            self.packages.${system}.default.buildInputs
+          ];
+
+          doCheck = false; # Disables automatically running tests for `$ nix develop` and direnv
+
+          # Warnings due to llvmPackages.stdenv result in compile error on debug, improve the llvmPackages.stdenv by
+          # `cargo build -r` worked but `cargo build` doesnt work
+          shellHook = ''
+            export CC="${llvmPackage.stdenv.cc}/bin/clang";
+            export CXX="${llvmPackage.stdenv.cc}/bin/clang++";
+            export LIBCLANG_PATH="${llvmPackage.libclang.lib}/lib";
+            export BINDGEN_CFLAGS="$(< ${llvmPackage.stdenv.cc}/nix-support/libc-crt1-cflags) \
+              $(< ${llvmPackage.stdenv.cc}/nix-support/libc-cflags) \
+              $(< ${llvmPackage.stdenv.cc}/nix-support/cc-cflags) \
+              $(< ${llvmPackage.stdenv.cc}/nix-support/libcxx-cxxflags) \
+              -idirafter ${llvmPackage.stdenv.cc.cc.lib}/lib/clang/${pkgs.lib.getVersion llvmPackage.stdenv.cc.cc}/include"
+            export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${pkgs.wayland}/lib";
+
+            export ZDOTDIR=$(mktemp -d)
+            cat > "$ZDOTDIR/.zshrc" << 'EOF'
+              source ~/.zshrc # Source the original ~/.zshrc, required.
+
+              function parse_git_branch {
+                git branch --no-color 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/\ ->\ \1/'
+              }
+
+              function display_jobs_count_if_needed {
+                local job_count=$(jobs -s | wc -l | tr -d " ")
+
+                if [ $job_count -gt 0 ]; then
+                  echo "%B%F{yellow}%j| ";
+                fi
+              }
+
+              # NOTE: Custom prompt with a snowflake: signals we are in `$ nix develop` shell
+              PROMPT="%F{blue}$(date +%H:%M:%S) $(display_jobs_count_if_needed)%B%F{green}%n %F{blue}%~%F{cyan} ❄%F{yellow}$(parse_git_branch) %f%{$reset_color%}"
+            EOF
+
+            if [ -z "$DIRENV_IN_ENVRC" ]; then # This makes `$ nix develop` universally working with direnv without infinite loop
+              exec ${pkgs.zsh}/bin/zsh -i
+            fi
+          '';
+        };
+
+        formatter = pkgs.nixpkgs-fmt;
+
+        apps = {
+          default = {
+            type = "app";
+            program = "${self.packages.${system}.default}/bin/cuervo";
+          };
+        };
+
+        # TODO: Finish it up below:
+        packages = rec {
+          # TODO: Do this:
+          default = rustPlatform.buildRustPackage {
+            pname = "cuervo";
+            version = "0.1.0";
+            src = ./.;
+            cargoLock.lockFile = ./Cargo.lock;
+            cargoVendorDir = null; # 👈 disable nix cargo vendor isolation, it was needed for servo vendoring before
+            cargoLock.outputHashes = {
+              "background_hang_monitor-0.0.1" = "sha256-z9JQ9rrlDWYyf+nRgjru3VIcK5MiMdnrq6LOFFGx5EY=";
+              "dom-0.0.1" = "sha256-rOEvolq3NydznfeM9eq8n1Cl3E1bds1wyzhoerYIWJs=";
+              "fontsan-0.5.2" = "sha256-4id66xxQ8iu0+OvJKH77WYPUE0eoVa9oUHmr6lRFPa8=";
+              "mozjs-0.14.1" = "sha256-q+kGrz2A6HRgJNtnUsc9btTjgXHyFRM0mxG/6QUfZYI=";
+              "naga-24.0.0" = "sha256-QxEAJP/N8GgwRrHHIvPV0u2OSelMAbhk2/u9bP8fQlg=";
+              "peek-poke-0.3.0" = "sha256-WCZYX68vZrPhaAZwpx9/lUp3bVsLMwtmlJSW8wNb2ks=";
+              "servo-media-0.1.0" = "sha256-KISNnnOjM6Fuxd6JkAlq2o4Wn5ChhN9UDYPPq2kCzvs=";
+              "signpost-0.1.0" = "sha256-xRVXwW3Gynace9Yk5r1q7xA60yy6xhC5wLAyMJ6rPRs=";
+              "surfman-0.9.8" = "sha256-bF5Oiw0ZRavovOaaFRegX55CdFFo/yuDn9lk+JEyCcA=";
+              "webxr-0.0.1" = "sha256-Hc71BvOFCo41HZtTCp1Hj6YBAwxQJgIzSEMVMM9y6JE=";
+            };
+            nativeBuildInputs = [ 
+              pkgs.pkg-config 
+              llvmPackage.clang
+              llvmPackage.libclang
+            ];
+            buildInputs = [ 
+              pkgs.wayland
+              pkgs.xorg.libX11.dev
+              pkgs.fontconfig
+              pkgs.libunwind
+            ];
+            doCheck = false; # NOTE: When there are tests, do this true
+            # # NOTE: This still doesnt pass: include!("../style/counter_style/predefined.rs"); error on servo_atoms
+            # preBuild = ''
+            #   mkdir -p vendor/servo
+            #   cp -r ${pkgs.fetchgit {
+            #     url = "https://github.com/servo/servo";
+            #     rev = "3a9476469ba4bbc0297b0d06c1ccdd4261f6f3ee";
+            #     sha256 = "sha256-z9JQ9rrlDWYyf+nRgjru3VIcK5MiMdnrq6LOFFGx5EY=";
+            #   }} vendor/servo
+            # '';
+            # # NOTE: try this:
+            # preBuild = ''
+            #   mkdir -p other
+            #   if [ ! -d other/servo ]; then
+            #     echo "Fetching Servo (with submodules)..."
+            #     ${pkgs.git}/bin/git clone --recursive https://github.com/mcclure/servo other/servo
+            #     (cd other/servo && ${pkgs.git}/bin/git checkout 3a9476469ba4bbc0297b0d06c1ccdd4261f6f3ee)
+            #   fi
+            # '';
+
+            postInstall = ''
+              echo "Installed cuervo to $out/bin"
+            '';
+            meta = {
+              description = "An example Rust binary built with Nix flakes";
+              license = pkgs.lib.licenses.mit;
+            };
+          };
+
+          development = default;
+
+          production = default;
+
+          # dockerImage = pkgs.dockerTools.buildLayeredImage {
+          #   name = "cuervo";
+          #   tag = "dev";
+          #   created = "now";
+          #   contents = [
+          #     pkgs.zsh
+          #     pkgs.coreutils
+          #     # pkgs.cacert
+          #     self.packages.${system}.default
+          #   ];
+          #   config = {
+          #     # Env = [
+          #     #   "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+          #     # ];
+          #     Cmd = [ "/bin/cuervo" ];
+          #   };
+          # };
+        };
+      }
+    );
+}


### PR DESCRIPTION
Hi there,

It took me about a day to compile this via `nix develop` shell(then `cargo build -r`) on NixOS, only way to make it run for now.

I still couldn't manage to build it via `nix build`. I'll learn `servo` more in-depth and then maybe I can contribute it here. 

Regardless thank for the inspiration, I really would like a servo based [carbonyl](https://github.com/fathyb/carbonyl) so I can distribute my web SPAs as TUI and ship it eventually to all platforms with a terminal.